### PR TITLE
fix(doc): docker-compose is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Check out the [post](https://testdriven.io/blog/django-and-celery/).
 Spin up the containers:
 
 ```sh
-$ docker-compose up -d --build
+$ docker compose up -d --build
 ```
 
 Open your browser to http://localhost:1337 to view the app or to http://localhost:5555 to view the Flower dashboard.


### PR DESCRIPTION
docker-compose is deprecated in version 2. Check it out [here](https://docs.docker.com/compose/migrate/). `docker compose` is recommended instead of docker-compose.`